### PR TITLE
Update dependency ember-handlebars-brunch to v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "uglify-js-brunch": ">= 1.0 < 2.0",
     "clean-css-brunch": ">= 1.0 < 2.0",
     "sass-brunch": "1.6",
-    "ember-handlebars-brunch": "1.0.4"
+    "ember-handlebars-brunch": "1.2.0"
   },
   "devDependencies": {
     "mocha": "0.14.0",


### PR DESCRIPTION
This Pull Request updates dependency [ember-handlebars-brunch](https://github.com/bartsqueezy/ember-handlebars-brunch) from `v1.0.4` to `v1.2.0`




<details>
<summary>Commits</summary>

#### v1.1.0
-   [`3e18c74`](https://github.com/bartsqueezy/ember-handlebars-brunch/commit/3e18c74a9205c1c6a3396c38e220875e2e1b4a08) Restore the expected wrapper behavior as bunch&#x27;s config.modules.wrapper is either &#x27;commonjs&#x27;, &#x27;amd&#x27;, or false. The value is never true. See https://github.com/brunch/brunch/blob/master/docs/config.md#modules.
-   [`cb6689f`](https://github.com/bartsqueezy/ember-handlebars-brunch/commit/cb6689fc1b0c1da1f3596f5cb4017aa71a28189b) Use the configured default extension
-   [`0e6eaaf`](https://github.com/bartsqueezy/ember-handlebars-brunch/commit/0e6eaaf0900fdcb84580f369a8512af6d26427ee) Adds travis integration
-   [`56133b8`](https://github.com/bartsqueezy/ember-handlebars-brunch/commit/56133b857e52a24cd305a74b10128cd50b9a5705) Adds travis tests badge
-   [`0445b47`](https://github.com/bartsqueezy/ember-handlebars-brunch/commit/0445b472b93c0630502f7df4ebe77f75cdb7b33f) npm version bump to 1.0.1
-   [`56163fb`](https://github.com/bartsqueezy/ember-handlebars-brunch/commit/56163fbdb8855f3a415e1379ac3be921bfe77ff6) Merge branch &#x27;master&#x27; of https://github.com/bartsqueezy/ember-handlebars-brunch
-   [`7ed492a`](https://github.com/bartsqueezy/ember-handlebars-brunch/commit/7ed492a4082715ff9fc787e1dc21385a57fa2543) let npm control updating of handlebars library, update ember-compiler to version 1.1.0, bump npm version to 1.1.0
-   [`1af1fbb`](https://github.com/bartsqueezy/ember-handlebars-brunch/commit/1af1fbbe190d12a90911c7606d15741aae4c9f92) Updated README.md
-   [`d0a7da2`](https://github.com/bartsqueezy/ember-handlebars-brunch/commit/d0a7da22b202621be8855e4eb03c984f442f0285) updating travis tag to point to correct project.  apply changes from @&#8203;gcollazo to fix tests
#### v1.1.1
-   [`2a1aa30`](https://github.com/bartsqueezy/ember-handlebars-brunch/commit/2a1aa306a9b1753883f8e17067c7a086acd6dad6) upgrading to ember 1.1.1
-   [`411d243`](https://github.com/bartsqueezy/ember-handlebars-brunch/commit/411d243f01fa93ca76ff83b15477425d6dcea254) npm version bump to 1.1.1
#### v1.2.0
-   [`b418758`](https://github.com/bartsqueezy/ember-handlebars-brunch/commit/b418758160f4720d86a1e259919ec50c59d395cc) upgrading ember to 1.2.0 and handlebars to 1.1.2

</details>