### PR TITLE
Update dependency mocha to v0.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-handlebars-brunch": "1.0.4"
   },
   "devDependencies": {
-    "mocha": "0.14.0",
+    "mocha": "0.14.1",
     "expect.js": "0.1.2",
     "express": "2.5.8"
   }


### PR DESCRIPTION
This Pull Request updates dependency [mocha](https://github.com/mochajs/mocha) from `v0.14.0` to `v0.14.1`



<details>
<summary>Release Notes</summary>

### [`v0.14.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;0141--2012-03-06)

- Added lib-cov to _.npmignore_
- Added reporter to `mocha.run([reporter])` as argument
- Added some margin-top to the HTML reporter
- Removed jQuery dependency
- Fixed `--watch`: purge require cache. Closes #&#8203;266

---

</details>