### PR TITLE
Update dependency uglify-js-brunch to >= 1.0.0 < 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "javascript-brunch": ">= 1.0 < 2.0",
     "coffee-script-brunch": ">= 1.0 < 2.0",
     "css-brunch": ">= 1.0 < 2.0",
-    "uglify-js-brunch": ">= 1.0 < 2.0",
+    "uglify-js-brunch": ">= 1.0.0 < 3.0",
     "clean-css-brunch": ">= 1.0 < 2.0",
     "sass-brunch": "1.6",
     "ember-handlebars-brunch": "1.0.4"


### PR DESCRIPTION
This Pull Request updates dependency [uglify-js-brunch](https://github.com/brunch/uglify-js-brunch) from `>= 1.0 < 2.0` to `>= 1.0.0 < 3.0`



<details>
<summary>Release Notes</summary>

### [`v2.0.0`](https://github.com/brunch/uglify-js-brunch/blob/master/CHANGELOG.md#uglify-js-brunch-200-Jan-29-2016)

* Updated source code & API. The plugin would now only work with Brunch 2.2 and higher.

---

### [`v2.0.1`](https://github.com/brunch/uglify-js-brunch/blob/master/CHANGELOG.md#uglify-js-brunch-201-Jan-29-2016)

* Updated uglify-js to 2.6.

---

</details>


<details>
<summary>Commits</summary>

#### v2.0.0
-   [`89424de`](https://github.com/brunch/uglify-js-brunch/commit/89424dee6b96b593206577c04cc6ac5927914f7d) Update interface to 2.0
-   [`01fb350`](https://github.com/brunch/uglify-js-brunch/commit/01fb350772c40cdef06a539d6673efe43dc31def) Merge pull request #&#8203;29 from hellyeahllc/update-iface-2.0
-   [`8edd66b`](https://github.com/brunch/uglify-js-brunch/commit/8edd66bd936e340b8edca96422a538035ef84d0f) Release 2.0.0.
#### v2.0.1
-   [`52b32b2`](https://github.com/brunch/uglify-js-brunch/commit/52b32b2d024786e9501c1f71b02ab36ed794ab51) Update uglify.
-   [`6e3a4b2`](https://github.com/brunch/uglify-js-brunch/commit/6e3a4b20e4ef1b919da92c5325cb4d9808e53ae3) Release 2.0.1.
#### v2.1.0
-   [`c2cf8d3`](https://github.com/brunch/uglify-js-brunch/commit/c2cf8d3112440b4b35dd060cb9e09c5035cece3a) Add travis.
-   [`17d76e6`](https://github.com/brunch/uglify-js-brunch/commit/17d76e6fc82bff20b336d0b0010f9f91d48cf3fd) Update ESLint to 2.1.0
-   [`c2e3848`](https://github.com/brunch/uglify-js-brunch/commit/c2e3848fdd51f9044e6a3a95ca7e8276d200038c) Merge pull request #&#8203;30 from brunch/eslint2
-   [`4c7d45e`](https://github.com/brunch/uglify-js-brunch/commit/4c7d45ea237535005d9e609cf5af502966a33cf5) Fix.
-   [`060c641`](https://github.com/brunch/uglify-js-brunch/commit/060c641c395d7d2ce2fe897d95ef2e3bd1e18218) Fix brunch/brunch#&#8203;1486 (#&#8203;32)
-   [`6bc8c66`](https://github.com/brunch/uglify-js-brunch/commit/6bc8c66787c3dfa4430de1a589095909e17d9294) README: Rewrite examples in coffee to js (#&#8203;33)
-   [`67d488b`](https://github.com/brunch/uglify-js-brunch/commit/67d488b8a322557ae85e012faf9dd66f6d80bdac) Use latest Node.js in Travis (#&#8203;34)
-   [`941b80c`](https://github.com/brunch/uglify-js-brunch/commit/941b80c4b5de3a82ef891ecf142d4f3bd8f85853) Use eslint-config-brunch (#&#8203;35)
-   [`ba836e8`](https://github.com/brunch/uglify-js-brunch/commit/ba836e89c2e0ba1257ac2ae0f8da17c33256dff5) Fix eslint (#&#8203;37)
-   [`2fc0b02`](https://github.com/brunch/uglify-js-brunch/commit/2fc0b02b15f06e31c008dcac84a563a3228fe1f6) Fix ESLint errors and warnings (#&#8203;38)
-   [`da9a1b9`](https://github.com/brunch/uglify-js-brunch/commit/da9a1b91aa117b7370202349703d85b122238f26) Fix source maps (#&#8203;39)
-   [`b0673d1`](https://github.com/brunch/uglify-js-brunch/commit/b0673d192da90dd4e4afa1eb2334935bad13a19c) Skemata handles that
-   [`1e461de`](https://github.com/brunch/uglify-js-brunch/commit/1e461de24753e4b7937cf088cf9d47997dd13601) Update uglifyjs dependency
-   [`335fdd2`](https://github.com/brunch/uglify-js-brunch/commit/335fdd20a45085723bafb5de56093b8ae67431db) Fix Travis
-   [`db1ae32`](https://github.com/brunch/uglify-js-brunch/commit/db1ae3248f3dcbaed84e067ce6d7c7bd510c2cf0) Improve tests
-   [`c4bd027`](https://github.com/brunch/uglify-js-brunch/commit/c4bd02769d504478e2bd5dbfae81f59e7a90659f) Release 2.1.0.
#### v2.1.1
-   [`064c2a8`](https://github.com/brunch/uglify-js-brunch/commit/064c2a804fe28b6453fe9ded3102030095be472b) Downgrade uglify, new version is shitty
-   [`b6f8312`](https://github.com/brunch/uglify-js-brunch/commit/b6f8312f8a3154d3aa3a79b01d2b0ff462526096) Release 2.1.1.
#### v2.10.0
-   [`65a2952`](https://github.com/brunch/uglify-js-brunch/commit/65a2952fca10cc87b07c690cf7719ba412b3003c) Improve error formatting.
-   [`8c67a01`](https://github.com/brunch/uglify-js-brunch/commit/8c67a01d4e9792b3d0cef2694163abdca987fbdf) Release 2.10.0.

</details>